### PR TITLE
Implemented EZP-20526: make item type human readable in class edit

### DIFF
--- a/design/standard/templates/class/datatype/edit/ezrecommendation.tpl
+++ b/design/standard/templates/class/datatype/edit/ezrecommendation.tpl
@@ -25,14 +25,11 @@
 {*ezrecommendation Item Type ID*}
 <div class="block">
     <label for="ContentClass_ezrecommendation_class_reco_item_type_value_{$class_attribute.id}">{'Item type (for recommendation)'|i18n( 'design/standard/class/datatype' )}: </label>
-      <select id="ContentClass_ezrecommendation_class_reco_item_type_value_{$class_attribute.id}" name="ContentClass_ezrecommendation_class_reco_item_type_value_{$class_attribute.id}" size="1">
-          <option value="1" {if eq( $class_attribute.data_int1, 1 )}selected="selected"{/if}>1</option>
-          <option value="2" {if eq( $class_attribute.data_int1, 2 )}selected="selected"{/if}>2</option>
-          <option value="3" {if eq( $class_attribute.data_int1, 3 )}selected="selected"{/if}>3</option>
-          <option value="4" {if eq( $class_attribute.data_int1, 4 )}selected="selected"{/if}>4</option>
-          <option value="5" {if eq( $class_attribute.data_int1, 5 )}selected="selected"{/if}>5</option>
-          <option value="6" {if eq( $class_attribute.data_int1, 6 )}selected="selected"{/if}>6</option>
-        </select>
+    <select id="ContentClass_ezrecommendation_class_reco_item_type_value_{$class_attribute.id}" name="ContentClass_ezrecommendation_class_reco_item_type_value_{$class_attribute.id}" size="1">
+    {foreach ezini( 'TypeSettings', 'Map', 'ezrecommendation.ini' ) as $id => $label}
+        <option value="{$id}" {if eq( $class_attribute.data_int1, $id )}selected="selected"{/if}>{$label|i18n( 'extension/ezrecommendation', false, 'item type' )} ({$id})</option>
+    {/foreach}
+    </select>
 </div>
 
 <br />

--- a/design/standard/templates/i18n.tpl
+++ b/design/standard/templates/i18n.tpl
@@ -1,0 +1,8 @@
+{* This file contains static version of default INI settings for translation generation purpose *}
+
+{* ezrecommendation.ini: TypeSettings.Map *}
+{"Product"|i18n( 'extension/ezrecommendation', false(), 'Item type' )}
+{"Article"|i18n( 'extension/ezrecommendation', false(), 'Item type' )}
+{"Image"|i18n( 'extension/ezrecommendation', false(), 'Item type' )}
+{"Media"|i18n( 'extension/ezrecommendation', false(), 'Item type' )}
+{"User generated content"|i18n( 'extension/ezrecommendation', false(), 'Item type' )}

--- a/settings/ezrecommendation.ini
+++ b/settings/ezrecommendation.ini
@@ -86,3 +86,11 @@ AvailableScenarios[top_purchased]=Top purchased
 AvailableScenarios[top_purchased_product]=Top purchased product
 AvailableScenarios[ultimately_bought]=Ultimately bought
 DefaultItemLimit=3
+
+[TypeSettings]
+Map[]
+Map[1]=Product
+Map[2]=Article
+Map[3]=Image
+Map[4]=Media
+Map[5]=User generated content


### PR DESCRIPTION
Adds an ini array in `ezrecommendation.ini`: `TypeSettings.Map`: `array( <ItemId> => <ItemLabel> )`.
