### PR TITLE
Fixed EZP-21076: generated ezreco divs are not unique

### DIFF
--- a/classes/ezrecommendationserverapi.php
+++ b/classes/ezrecommendationserverapi.php
@@ -85,7 +85,7 @@ class eZRecommendationServerAPI
         $classId = eZContentClass::classIDByIdentifier( $classIdentifier );
         $arr = ezRecommendationClassAttribute::fetchClassAttributeList( $classId );
 
-        return count( $arr['result'] ) > 0 ? $arr['result']['recoItemType'] : false;
+        return ( isset( $arr['result'] ) && count( $arr['result'] ) ) ? $arr['result']['recoItemType'] : false;
     }
 
     /**

--- a/design/standard/templates/content/recommendations.tpl
+++ b/design/standard/templates/content/recommendations.tpl
@@ -1,5 +1,6 @@
 {def $scenario_name = cond( $scenario|eq( '' ), ezini( 'RecommendationSettings', 'DefaultScenario', 'ezrecommendation.ini' ), $scenario )
-     $div_id = concat( 'ezrecommendation-recommendations', $node.node_id )}
+     $div_id_hash = concat( $node.node_id, $scenario, $numrecs, $output_itemtypeid, $category_based, $create_clickrecommended_event, $track_rendered_items )|md5
+     $div_id = concat( 'ezreco-reco-', $div_id_hash )}
 <script type="text/javascript">
 $(document).ready(function () {ldelim}
 


### PR DESCRIPTION
Issue: http://jira.ez.no/browse/EZP-21076

This PR makes the generated div ids unique by appending an md5 hash that depends on the include arguments.
