### PR TITLE
Implemented EZP-22541: recommendations cache

### DIFF
--- a/bin/getrecommendation.php
+++ b/bin/getrecommendation.php
@@ -4,7 +4,7 @@ require 'autoload.php';
 
 $script = eZScript::instance(
     array(
-        'description' => ( "Gets recommendations for a content id" ),
+        'description' => ( "Test script that gets recommendations for a content id" ),
         'use-session' => false,
         'use-modules' => true,
         'use-extensions' => true

--- a/settings/debug.ini.append.php
+++ b/settings/debug.ini.append.php
@@ -2,5 +2,6 @@
 
 [GeneralCondition]
 extension-ezrecommendation=disabled
+extension-ezrecommendation-cache=disabled
 
 */

--- a/settings/ezrecommendation.ini.append.php
+++ b/settings/ezrecommendation.ini.append.php
@@ -28,6 +28,16 @@ SiteURL=
 BulkPath=
 # Default bulk XML entrys
 XmlEntries=1000
+
+[PerformanceSettings]
+# Set to > 0 to activate a local cache of recommendations gotten from service (expressed in seconds).
+# The reco service will always be contacted, but the processed results will be cached,
+# based on user-perms, scenario id and recommended items.
+# This is a good idea performance-wise, but beware if you base your recommendation-display templates on other data as well.
+# (also, you might get in the recommendations some objects which have been deleted from content)
+# This cache can be purged by purging cache blocks the usual way.
+RecommendationTTL=0
+
 #################################################################
 # The following are settings which are controlled by yoochoose	#
 # and should only be changed in consultation with yoochoose.	#


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-22541
> Based on #30 by @gggeek 

Implements TTL based recommendations caching in the ezjscore callback.
## Usage

Disabled by default, can be enabled by setting `PerformanceSettings.RecommendationTTL` to a value > 0 in `ezrecommendation.ini`. HIT/MISS/STORE can be debuggued by enabling the `extension-ezrecommendation-cache` debug flag in `debug.ini`.
## Implementation

Cache is implemented cache blocks. Keys include:
- scenario
- user roles & policies
- recommended items ids and categories
## Testing

A test script, `bin/getrecommendation.php` script has been added.
It fetches recommendations for a given node id, using either `eZRecommendationServerAPI` (defaul) or the ezjscore callback.
When reco cache & CLI debug are enabled, hits and misses can be seen in the console output.
## TODO
- [ ] squash
