### PR TITLE
Fix EZP-22750: missing exception handling in ezreco workflow events

### DIFF
--- a/eventtypes/event/ezrecobuyevent/ezrecobuyeventtype.php
+++ b/eventtypes/event/ezrecobuyevent/ezrecobuyeventtype.php
@@ -114,7 +114,15 @@ class eZRecoBuyEventType extends eZWorkflowEventType
 
                         $path = '/'.$solution.'/'.$client_id.'/buy'.'/'.$userid.'/'.$recoitemtypeid.'/'.$main_node_id.'?quantity='.$count.'&fullprice='.$price.'&timestamp='.$timestamp.'&categorypath='.$pathString;
 
-                        ezRecoFunctions::send_http_request($url, $path);
+                        try
+                        {
+                            ezRecoFunctions::send_http_request($url, $path);
+                        }
+                        catch ( eZRecommendationApiException $e )
+                        {
+                            eZDebug::writeError( '[ezrecommendation] http request failed', $path );
+                            return false;
+                        }
                     }else{
                         continue;
                     }

--- a/eventtypes/event/ezrecodeleteevent/ezrecodeleteeventtype.php
+++ b/eventtypes/event/ezrecodeleteevent/ezrecodeleteeventtype.php
@@ -44,9 +44,16 @@ class eZRecoDeleteEventType extends eZWorkflowEventType
         else
         {
             $api = new eZRecommendationServerAPI();
-            foreach ( $parameters['node_id_list'] as $nodeID )
+            try
             {
-                $api->deleteItem( $nodeID );
+                foreach ( $parameters['node_id_list'] as $nodeID )
+                {
+                        $api->deleteItem( $nodeID );
+                }
+            }
+            catch ( eZRecommendationApiException $e )
+            {
+                return eZWorkflowType::STATUS_REJECTED;
             }
         }
         return eZWorkflowType::STATUS_ACCEPTED;

--- a/eventtypes/event/ezrecoexportevent/ezrecoexporteventtype.php
+++ b/eventtypes/event/ezrecoexportevent/ezrecoexporteventtype.php
@@ -34,7 +34,15 @@ class eZRecoExportEventType extends eZWorkflowEventType
         $objectID = $processParameters['object_id'];
 
         $api = new eZRecommendationServerAPI();
-        $api->exportObject( $objectID );
+        try
+        {
+            $api->exportObject( $objectID );
+        }
+        catch ( eZRecommendationApiException $e )
+        {
+            return eZWorkflowType::STATUS_REJECTED;
+        }
+
         return eZWorkflowType::STATUS_ACCEPTED;
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22750

This adds exception handling to the workflow events to make sure there are no fatal/transaction errors when http requests fail in `ezRecoFunctions` ( and `eZRecommendationAPI`, indirectly).

Disclaimer: untested
